### PR TITLE
use standard 1bp insert style by default

### DIFF
--- a/hgvs/__init__.py
+++ b/hgvs/__init__.py
@@ -1364,7 +1364,7 @@ def parse_hgvs_name(hgvs_name, genome, transcript=None,
 
 
 def variant_to_hgvs_name(chrom, offset, ref, alt, genome, transcript,
-                         max_allele_length=4):
+                         max_allele_length=4, use_counsyl=False):
     """
     Populate a HGVSName from a genomic coordinate.
 
@@ -1394,9 +1394,11 @@ def variant_to_hgvs_name(chrom, offset, ref, alt, genome, transcript,
     else:
         # Use cDNA coordinates.
         hgvs.kind = 'c'
-        if (mutation_type == '>' or
-                mutation_type == 'ins' and len(alt) == 1 or
-                mutation_type in ('del', 'delins', 'dup') and len(ref) == 1):
+        is_single_base_indel = (
+            (mutation_type == 'ins' and len(alt) == 1) or
+            (mutation_type in ('del', 'delins', 'dup') and len(ref) == 1))
+
+        if mutation_type == '>' or (use_counsyl and is_single_base_indel):
             # Use a single coordinate.
             hgvs.cdna_start = genomic_to_cdna_coord(transcript, offset)
             hgvs.cdna_end = hgvs.cdna_start
@@ -1458,6 +1460,7 @@ def format_hgvs_name(chrom, offset, ref, alt, genome, transcript,
     max_allele_length: If allele is greater than this use allele length.
     """
     hgvs = variant_to_hgvs_name(chrom, offset, ref, alt, genome, transcript,
-                                max_allele_length=max_allele_length)
+                                max_allele_length=max_allele_length,
+                                use_counsyl=use_counsyl)
     return hgvs.format(use_prefix=use_prefix, use_gene=use_gene,
                        use_counsyl=use_counsyl)

--- a/hgvs/tests/test_hgvs_names.py
+++ b/hgvs/tests/test_hgvs_names.py
@@ -133,6 +133,30 @@ def test_variant_to_name():
                 repr([hgvs_name, expected_hgvs_name, variant]))
 
 
+def test_variant_to_name_counsyl():
+    """
+    Convert variant coordinates to HGVS names with counsyl-specific style.
+    """
+    genome = MockGenomeTestFile(
+        db_filename='hg19.fa',
+        filename='hgvs/tests/data/test_variant_to_name.genome',
+        create_data=False)
+
+    for (expected_hgvs_name, variant,
+         name_canonical, var_canonical) in _name_variants_counsyl:
+        if name_canonical:
+            transcript_name = HGVSName(expected_hgvs_name).transcript
+            transcript = get_transcript(transcript_name)
+            assert transcript, transcript_name
+            chrom, offset, ref, alt = variant
+            hgvs_name = format_hgvs_name(
+                chrom, offset, ref, alt, genome, transcript,
+                use_gene=False, use_counsyl=True)
+            nose.tools.assert_equal(
+                hgvs_name, expected_hgvs_name,
+                repr([hgvs_name, expected_hgvs_name, variant]))
+
+
 def test_name_to_variant_refseqs():
     """
     Convert HGVS names to variant coordinates using refseqs directly.
@@ -685,7 +709,7 @@ _name_variants = [
     ('NM_000016.4:c.475delT', ('chr1', 76205669, 'AT', 'A'), True, True),
     ('NM_000016.4:c.1189dupT', ('chr1', 76227049, 'C', 'CT'), True, True),
     ('NM_000016.4:c.1191delT', ('chr1', 76227051, 'AT', 'A'), True, True),
-    ('NM_000016.4:c.307insG', ('chr1', 76199232, 'T', 'TG'), True, True),
+    ('NM_000016.4:c.306_307insG', ('chr1', 76199232, 'T', 'TG'), True, True),
 
     # Alignment tests for HGVS 3' and VCF left-alignment.
     ('NM_000492.3:c.935_937delTCT', ('chr7', 117180210, 'CCTT', 'C'),
@@ -725,6 +749,11 @@ _name_variants = [
     # Non-canonical.
     ('NM_000492.3:c.1210-7_1210-6dupTT',
      ('chr7', 117188682, 'GTT', 'GTTTT'), True, False),
+]
+
+
+_name_variants_counsyl = [
+    ('NM_000016.4:c.307insG', ('chr1', 76199232, 'T', 'TG'), True, True),
 ]
 
 


### PR DESCRIPTION
@alexfrieden cc @insane

Fixes #10.  This PR ensures that 1bp inserts also use an interval for coordinates, i.e. `X_YinsG` for an insert between coordinates X and Y.
