### PR TITLE
Catch invalid coordinates in HGVS names

### DIFF
--- a/pyhgvs/__init__.py
+++ b/pyhgvs/__init__.py
@@ -92,7 +92,6 @@ BASE = [ACGT]
 BASES = BASE+
 
 """
-
 import re
 
 from .variants import justify_indel
@@ -746,6 +745,7 @@ class HGVSName(object):
         # Parse prefix and allele.
         self.parse_allele(allele)
         self.parse_prefix(prefix, self.kind)
+        self._validate()
 
     def parse_prefix(self, prefix, kind):
         """
@@ -969,6 +969,13 @@ class HGVSName(object):
                 return
 
         raise InvalidHGVSName(details, 'genomic allele')
+
+    def _validate(self):
+        """
+        Check for internal inconsistencies in representation
+        """
+        if self.start > self.end:
+            raise InvalidHGVSName(reason="Coordinates are nonincreasing")
 
     def __repr__(self):
         try:

--- a/pyhgvs/tests/test_hgvs_names.py
+++ b/pyhgvs/tests/test_hgvs_names.py
@@ -11,6 +11,7 @@ except:
 from .. import CDNACoord
 from .. import CDNA_STOP_CODON
 from .. import HGVSName
+from .. import InvalidHGVSName
 from .. import cdna_to_genomic_coord
 from .. import format_hgvs_name
 from .. import genomic_to_cdna_coord
@@ -175,6 +176,19 @@ def test_name_to_variant_refseqs():
         nose.tools.assert_equal(
             hgvs_variant, variant,
             repr([hgvs_name, variant, hgvs_variant]))
+
+
+@nose.tools.raises(InvalidHGVSName)
+def test_invalid_coordinates():
+    """
+    Regression test for 17
+    """
+    if not SequenceFileDB:
+        raise nose.SkipTest
+
+    genome = SequenceFileDB('pyhgvs/tests/data/test_refseqs.fa')
+    hgvs_name = 'NC_000005.10:g.177421339_177421327delACTCGAGTGCTCC'
+    parse_hgvs_name(hgvs_name, genome, get_transcript=get_transcript)
 
 
 # Test examples of cDNA coordinates.

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from setuptools import setup
 from pip.req import parse_requirements
+from pip.download import PipSession
 import sys
 
 description = ("This library provides a simple to use Python API for parsing, "
@@ -32,7 +33,7 @@ def main():
         scripts=[],
         install_requires=['pip>=1.2'],
         tests_require=[str(line.req) for line in
-                       parse_requirements('requirements-dev.txt')],
+                       parse_requirements('requirements-dev.txt', session=PipSession())],
     )
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def main():
 
     setup(
         name='pyhgvs',
-        version='0.9.3',
+        version='0.9.4',
         description='HGVS name parsing and formatting',
         long_description=description,
         author='Matt Rasmussen',
@@ -33,7 +33,8 @@ def main():
         scripts=[],
         install_requires=['pip>=1.2'],
         tests_require=[str(line.req) for line in
-                       parse_requirements('requirements-dev.txt', session=PipSession())],
+                       parse_requirements('requirements-dev.txt',
+                                          session=PipSession())],
     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #17 

I'd also like to bump the version so we can use it in website, but Counsyl's PyPI lists the most recent version as 0.9.3 whereas `setup.py` is currently set to 0.9.2. Is there another version of this repo that we should be syncing up with?