### PR TITLE
Expanded handling for protein strings

### DIFF
--- a/pyhgvs/__init__.py
+++ b/pyhgvs/__init__.py
@@ -175,7 +175,7 @@ class HGVSRegex(object):
     PEP_REF2 = "(?P<ref2>" + PEP + ")"
     PEP_ALT = "(?P<alt>" + PEP + ")"
 
-    PEP_EXTRA = "(?P<extra>(|=|\?)(|fs))"
+    PEP_EXTRA = "(?P<extra>(|=|\?)(|fs((Ter|\*)\d+)?))"
 
     # Peptide allele syntax
     PEP_ALLELE = [

--- a/pyhgvs/__init__.py
+++ b/pyhgvs/__init__.py
@@ -170,7 +170,7 @@ class HGVSRegex(object):
                            for regex in CDNA_ALLELE]
 
     # Peptide syntax
-    PEP = "([A-Z]([a-z]{2}))+"
+    PEP = "(([A-Z]([a-z]{2}))|([GAVLIMFWPSTCYNQDEKRH\*]))+"
     PEP_REF = "(?P<ref>" + PEP + ")"
     PEP_REF2 = "(?P<ref2>" + PEP + ")"
     PEP_ALT = "(?P<alt>" + PEP + ")"


### PR DESCRIPTION
These are just a couple of small changes so that more protein HGVS strings can be parsed.  I added 1-letter amino acid codes (including '*' for termination) and termination codes for frameshifts.

example HGVS strings:
p.R97G
p.Arg97Glyfs*26
p.Arg97GlyfsTer26
p.R97Gfs*26
p.R97GfsTer26