### PR TITLE
Fix pip issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HGVS library change log
 
+## 0.9.5 (2018-07-01)
+  -  Fix pip installs by not using the internal API
+## 0.9.4  / 0.9.3 (2015-03-11)
+  - `NC_000005.10:g.177421339_177421327delACTCGAGTGCTCC` appears in ClinVar, and is an invalid name (the genomic start/stop coords are not in increasing order). This causes parse_hgvs_name to raise an IndexError. It should raise InvalidHGVSName instead
 ## 0.9.2 (2014-12-11)
   - Rename package to pyhgvs to avoid naming conflict with other libraries.
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from pip.req import parse_requirements
-from pip.download import PipSession
 import sys
 
 description = ("This library provides a simple to use Python API for parsing, "
@@ -20,7 +18,7 @@ def main():
 
     setup(
         name='pyhgvs',
-        version='0.9.4',
+        version='0.9.5',
         description='HGVS name parsing and formatting',
         long_description=description,
         author='Matt Rasmussen',
@@ -31,10 +29,7 @@ def main():
             '': ['requirements-dev.txt'],
         },
         scripts=[],
-        install_requires=['pip>=1.2'],
-        tests_require=[str(line.req) for line in
-                       parse_requirements('requirements-dev.txt',
-                                          session=PipSession())],
+        tests_require=[l.strip() for l in open('requirements-dev.txt') if l],
     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously this library used the pip internal API. Let's get rid of that instead.

Checked:

1. Tests still pass
2. Added release note (and backfilled older release note from #17 / #18).