### PR TITLE
Support recent versions of pip.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from pip.req import parse_requirements
-from pip.download import PipSession
+from pkg_resources import parse_requirements
 import sys
 
 description = ("This library provides a simple to use Python API for parsing, "
@@ -18,6 +17,9 @@ def main():
                "You have version %d.%d" % python_version[:2])
         sys.exit(1)
 
+    with open('requirements-dev.txt', 'r') as fp:
+      reqs_str = fp.read()
+
     setup(
         name='pyhgvs',
         version='0.9.4',
@@ -32,9 +34,7 @@ def main():
         },
         scripts=[],
         install_requires=['pip>=1.2'],
-        tests_require=[str(line.req) for line in
-                       parse_requirements('requirements-dev.txt',
-                                          session=PipSession())],
+        tests_require=[str(req) for req in parse_requirements(reqs_str)],
     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
The old setup.py imported a requirement string parsing
util from `pip.req`. That package is no longer available in
pip > 9.0.3. That version of pip is now very old and outdated.

In newer versions of pip, that parsing util is not part
of the public API. Fortunately, setuptools itself provides
a standard, public method for parsing requirements strings.

This change switches the code to use that setuptools method.

As a result, hgvs can now be installed using modern versions
of pip.