### PR TITLE
Fix genome creation in example script

### DIFF
--- a/examples/example1.py
+++ b/examples/example1.py
@@ -34,7 +34,7 @@ import pyhgvs.utils as hgvs_utils
 from pyfaidx import Fasta
 
 # Read genome sequence using pyfaidx.
-genome = Genome('/tmp/hg19.fa')
+genome = Fasta('/tmp/hg19.fa')
 
 # Read RefSeq transcripts into a python dict.
 with open('pyhgvs/data/genes.refGene') as infile:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def main():
 
     setup(
         name='pyhgvs',
-        version='0.11.1',
+        version='0.11.2',
         description='HGVS name parsing and formatting',
         long_description=description,
         author='Matt Rasmussen',


### PR DESCRIPTION
@ctk3b 

Fixes the example script. Confirmed I was able to run this script after this change.

```
$> python examples/example1.py
chr11 17496508 T C
NM_000352.3(ABCC8):c.215A>G
('NM_000352.3', 'c', '>', CDNACoord(215, -10), CDNACoord(215, -10), 'A', 'G')
```

compared to master which failed with:

```
$> python examples/example1.py
Traceback (most recent call last):
  File "examples/example1.py", line 37, in <module>
    genome = Genome('/tmp/hg19.fa')
NameError: name 'Genome' is not defined
```